### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/bot/commands/ticket/support.ts
+++ b/src/bot/commands/ticket/support.ts
@@ -119,7 +119,7 @@ export default class SupportCommand extends Command {
     )
 
     const ticketDescription = ticketType
-      ? description.substr(ticketType.length + 1)
+      ? description.slice(ticketType.length + 1)
       : description
     const title = ticketType ? types[ticketType].title : types.default.title
     const color = ticketType ? types[ticketType].color : types.default.color


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.